### PR TITLE
responseHandler: give `response` as third parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,18 +68,18 @@ function responseHandler (callback, options) {
     // var end = new Date()
 
     if (err) {
-      return callback(err);
+      return callback(err, null, response);
     }
 
     if (isError(response.statusCode)) {
       return createError(data, response, function (err) {
-        callback(err);
+        callback(err, null, response);
       });
     }
 
     var parse = options.parse || config.parse;
     data = isFunction(parse) ? parse(data, response) : data;
-    callback(null, data);
+    callback(null, data, response);
   };
 }
 


### PR DESCRIPTION
For things like checking the headers of a response.
